### PR TITLE
Fixing Counter and adding a few default counters into middleware

### DIFF
--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -127,7 +127,7 @@ class StatsdMiddleware(object):
         cls.scope.timings.start('total')
         cls.scope.counter = Counter(prefix)
         cls.scope.counter.increment('hit')
-        cls.scope.counter_site = Counter(prefix + '.site')
+        cls.scope.counter_site = Counter(prefix)
         cls.scope.counter_site.increment('hit')
         return cls.scope
 
@@ -164,7 +164,7 @@ class StatsdMiddleware(object):
             cls.scope.timings.stop('total')
             cls.scope.timings.submit(*key)
             cls.scope.counter.submit(*key)
-            cls.scope.counter_site.submit()
+            cls.scope.counter_site.submit('site')
 
     def process_response(self, request, response):
         if TRACK_MIDDLEWARE:


### PR DESCRIPTION
The Counter() class was being called with `.incr()` instead of `.increment()` which was breaking the counter.

Also, I think it's relatively interesting and easy to simply store how many page hits a specific view is getting.  I'm considering adding app specific counters.  Also, a site on the whole counter is useful.

Maybe number unique users at some point?
