### PR TITLE
Add the ability to set a global StatsD reporting prefix for a django project

### DIFF
--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -39,6 +39,9 @@ class Client(object):
     class_ = statsd.Client
 
     def __init__(self, prefix='view'):
+        global_prefix = getattr(settings, 'STATSD_PREFIX', None)
+        if global_prefix:
+            prefix = '%s.%s' % (global_prefix, prefix)
         self.prefix = prefix
         self.data = collections.defaultdict(int)
 


### PR DESCRIPTION
Useful if you have more than one Django site reporting to StatsD.

This setting complies with the equivalent setting in http://pypi.python.org/pypi/statsd/
