### PR TITLE
fix errors related to timers not started/not stopped

### DIFF
--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -171,6 +171,7 @@ class StatsdMiddleware(object):
     def process_template_response(self, request, response):
         if TRACK_MIDDLEWARE:
             StatsdMiddleware.scope.timings.stop('process_template_response')
+        return response
 
     def cleanup(self, request):
         self.scope.timings = None


### PR DESCRIPTION
I get a lot of requests that generate an error report saying that a timer wasn't started, or wasn't stopped. This is apparently because the two middleware classes don't start/stop the same set of timers.

Also, I changed them to use TRACK_MIDDLEWARE comprehensively. Before it was an error to set this to False, because not all of the timers were guarded. This should have been a separate commit, but I got lazy and didn't separate it out.
