### PR TITLE
kwarg get_response in MiddlewareMixin accepts None as default value

### DIFF
--- a/django_statsd/middleware.py
+++ b/django_statsd/middleware.py
@@ -125,7 +125,7 @@ class Timer(Client):
 class StatsdMiddleware(deprecation.MiddlewareMixin):
     scope = threading.local()
 
-    def __init__(self, get_response):
+    def __init__(self, get_response=None):
         deprecation.MiddlewareMixin.__init__(self, get_response)
         self.scope.timings = None
         self.scope.counter = None


### PR DESCRIPTION
The current implementation does not work for Django 1.11 due to incompatibility with kwarg **get_response** default value