### PR TITLE
Adding support for disable metrics

### DIFF
--- a/django_statsd/settings.py
+++ b/django_statsd/settings.py
@@ -21,6 +21,10 @@ STATSD_PREFIX = get_setting('STATSD_PREFIX')
 #: to DEBUG if not configured
 STATSD_DEBUG = get_setting('STATSD_DEBUG', get_setting('DEBUG'))
 
+#: Statsd disabled mode, avoids to send metrics to the real server.
+#: Useful for debugging purposes.
+STATSD_DISABLED = get_setting('STATSD_DISABLED', False)
+
 #: Enable creating tags as well as the bare version. This causes an ajax view
 #: to be stored both as the regular view name and as the ajax tag. Supported
 #: separators are _is_ and =
@@ -35,5 +39,3 @@ STATSD_PORT = get_setting('STATSD_PORT', 8125)
 #: Statsd sample rate, lowering this decreases the (random) odds of actually
 #: submitting the data. Between 0 and 1 where 1 means always
 STATSD_SAMPLE_RATE = get_setting('STATSD_SAMPLE_RATE', 1.0)
-
-

--- a/django_statsd/utils.py
+++ b/django_statsd/utils.py
@@ -2,7 +2,7 @@ import statsd
 from . import settings
 
 
-def get_connection(host=None, port=None, sample_rate=None):
+def get_connection(host=None, port=None, sample_rate=None, disabled=None):
     if not host:
         host = settings.STATSD_HOST
 
@@ -12,7 +12,10 @@ def get_connection(host=None, port=None, sample_rate=None):
     if not sample_rate:
         sample_rate = settings.STATSD_SAMPLE_RATE
 
-    return statsd.Connection(host, port, sample_rate)
+    if not disabled:
+        disabled = settings.STATSD_DISABLED
+
+    return statsd.Connection(host, port, sample_rate, disabled)
 
 
 def get_client(name, connection=None, class_=statsd.Client):


### PR DESCRIPTION
It allows to pass the `disabled` variable, and it will skip the call to the real server.

This, plus enabling the logs, are really useful for development purposes :)

Closes #15 